### PR TITLE
pman binary says it uses `sh` but it really needs `bash`

### DIFF
--- a/bin/pman
+++ b/bin/pman
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # from http://stackoverflow.com/a/697552/547956
 # get the absolute path of the executable


### PR DESCRIPTION
On centos, sh symlinks bash, but on ubutnu, sh symlinks to dash. Therefore this file fails on ubuntu.